### PR TITLE
UTF-8 Special characters bug

### DIFF
--- a/Support/lib/jsc.js
+++ b/Support/lib/jsc.js
@@ -27,7 +27,6 @@ Copyright (c) 2009 Apple Inc.
 /*global  JSLINT, JSHINT */
 
 
-
 (function(args) {
   var filename  = args[0],
       linter    = (typeof JSHINT !== 'undefined' ? JSHINT : JSLINT),
@@ -107,6 +106,14 @@ Copyright (c) 2009 Apple Inc.
     return linterOptions;
   }
 
+  /*** fix special chars ***/
+  function to_ascii(str) {
+    return str.replace(/[\u0080-\uffff]/g, function(ch) {
+      var code = ch.charCodeAt(0).toString(16);
+      while (code.length < 4) code = "0" + code;
+      return "\\u" + code;
+    });
+  }
 
 
   /*** Lint ***/
@@ -126,8 +133,6 @@ Copyright (c) 2009 Apple Inc.
     return linterData;
   }
 
-
-
   // Check for JS code
   if(!filename){
     print('Usage: jsc (jslint|jshint).js jsc.js -- "$(cat myFile.js)"' +
@@ -141,7 +146,7 @@ Copyright (c) 2009 Apple Inc.
   linterOptions = parseOptions(options);
 
   // Run linter and fetch data
-  linterData = findLint(linter, linterOptions, filename);
+  linterData = findLint(linter, linterOptions, to_ascii(filename));
 
   if(linterData.errors || linterData.unused){
     // Format errors

--- a/Support/lib/jsc.js
+++ b/Support/lib/jsc.js
@@ -27,6 +27,7 @@ Copyright (c) 2009 Apple Inc.
 /*global  JSLINT, JSHINT */
 
 
+
 (function(args) {
   var filename  = args[0],
       linter    = (typeof JSHINT !== 'undefined' ? JSHINT : JSLINT),
@@ -106,14 +107,6 @@ Copyright (c) 2009 Apple Inc.
     return linterOptions;
   }
 
-  /*** fix special chars ***/
-  function to_ascii(str) {
-    return str.replace(/[\u0080-\uffff]/g, function(ch) {
-      var code = ch.charCodeAt(0).toString(16);
-      while (code.length < 4) code = "0" + code;
-      return "\\u" + code;
-    });
-  }
 
 
   /*** Lint ***/
@@ -133,6 +126,8 @@ Copyright (c) 2009 Apple Inc.
     return linterData;
   }
 
+
+
   // Check for JS code
   if(!filename){
     print('Usage: jsc (jslint|jshint).js jsc.js -- "$(cat myFile.js)"' +
@@ -146,7 +141,7 @@ Copyright (c) 2009 Apple Inc.
   linterOptions = parseOptions(options);
 
   // Run linter and fetch data
-  linterData = findLint(linter, linterOptions, to_ascii(filename));
+  linterData = findLint(linter, linterOptions, filename);
 
   if(linterData.errors || linterData.unused){
     // Format errors

--- a/Support/lib/jslintmate/linter.rb
+++ b/Support/lib/jslintmate/linter.rb
@@ -100,7 +100,7 @@ module JSLintMate
       jsc = JSLintMate.lib_path('jsc.js')
       cmd = '/System/Library/Frameworks/JavaScriptCore.framework/' <<
                %{Versions/A/Resources/jsc "#{self.path}" "#{jsc}" -- } <<
-               %{"$(cat "#{filepath}")"}
+               %{"$(iconv -f utf8 -t ISO8859-1 "#{filepath}")"}
 
       cmd << %{ --linter-options-from-defaults="#{
         Linter.default_options.gsub('"', '\\"')


### PR DESCRIPTION
After installed and configured this bundle I realized that the warning "Unsafe character" was going in every line with a special character (In my case, all the jsdoc comments are in brazilian portuguese). I tried to find an option to ignore this, but looking at the warning I saw that the characters was not the same as my document (classic encoding error):

```
Unsafe character.
// {name} serÃ¡ substituÃ­do pelo valor selecionado;
line 217
```

The original line is: 

```
// {name} será substituí­do pelo valor selecionado;
```

I made some research and found out that this is a common bug of JSC and a work-around is to convert the encoding from utf-8 to iso8859-1. So, instead of using `cat` to send the content of the file, I used `iconv` assuming that the encoding will be UTF-8 (in the future this could be a custom value) 
